### PR TITLE
Make block range modifiable

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Gets token image and metadata
 * `saveDir` - *Optional* - Specify the save directory for the saved files. Only taken into account if the `save` option is `true`. Defaults to `.`
 * `filename` - *Optional* - Specify the name (without a file extension) for the saved file. Only taken into account if the `save` option is `true`. Defaults to `token_${id}.png`.
 * `cropped` - *Optional* - Whether the token image should be cropped (full image) or in the relative position it is on the MurAll canvas.
+* `fromBlock` - *Optional* - Start of the block range from which the log events are queried. Defaults to `earliest`.
+* `toBlock` - *Optional* - End of the block range from which the log events are queried. Defaults to `latest`.
 
 **Returns**
 `{ canvas, [metadata]}` - Object containing the node Canvas and a JSON metadata object, if metadata was also required.
@@ -85,6 +87,9 @@ Renders the token images from the given range on a single image in their respect
 * `saveDir` - *Optional* - Specify the save directory for the saved file. Only taken into account if the `save` option is `true`. Defaults to `.`
 * `filename` - *Optional* - Specify the name (without a file extension) for the saved file. Only taken into account if the `save` option is `true`. Defaults to `tokens_${from}-${to}.png`.
 * `initialState` - *Optional* - Canvas object to act as the initial state on which token images will be loaded. If not specified, the token images will be put onto a blank canvas.
+* `fromBlock` - *Optional* - Start of the block range from which the log events are queried. Defaults to `earliest`.
+* `toBlock` - *Optional* - End of the block range from which the log events are queried. Defaults to `latest`.
+
 
 **Returns**
 Canvas containing the token images. 

--- a/src/tokens/states.ts
+++ b/src/tokens/states.ts
@@ -12,6 +12,8 @@ export type ApplyChangesOptions = {
   readonly save?: boolean
   readonly saveDir?: string
   readonly filename?: string
+  readonly fromBlock?: number
+  readonly toBlock?: number
 }
 
 const imageFilename = (from: number, to: number, name?: string) => name ? `${name}.png` : `tokens_${from}-${to}.png`
@@ -23,8 +25,8 @@ export const apply = async (from = 0, to = 1, opts?: ApplyChangesOptions): Promi
   const murallContract = await web3.contracts.MurAll.get()
   const logEvents = await murallContract.getPastEvents('Painted', {
     filter: { tokenId: range(from, to) },
-    fromBlock: 'earliest',
-    toBlock: 'latest'
+    fromBlock: options.fromBlock || 'earliest',
+    toBlock: options.toBlock || 'latest'
   })
   const events = compact(logEvents.map(extract)) || []
   if (!events.length) throw new Error(`Failed to fetch log events for tokens ${from} to ${to}`)

--- a/src/tokens/token.ts
+++ b/src/tokens/token.ts
@@ -12,6 +12,8 @@ export type FetchTokenOptions = {
   readonly filename?: string
   readonly cropped?: boolean
   readonly includeMetadata?: boolean
+  readonly fromBlock?: number
+  readonly toBlock?: number
 }
 
 export type TokenData = {
@@ -29,8 +31,8 @@ export const get = async (id: number, opts?: FetchTokenOptions): Promise<TokenDa
   const murallContract = await web3.contracts.MurAll.get()
   const logEvents = await murallContract.getPastEvents('Painted', {
     filter: { tokenId: [id] },
-    fromBlock: 'earliest',
-    toBlock: 'latest'
+    fromBlock: options.fromBlock || 'earliest',
+    toBlock: options.toBlock || 'latest'
   })
   const [event] = logEvents.map(extract) || []
   if (!event) throw new Error(`Failed to fetch log event for token ${id}`)


### PR DESCRIPTION
This is mainly to facilitate faster querying of the Polygon log events. 
Sometimes the query even fails when block range is too large. Reducing the block range will prevent it from failing.

Changes:
* Allow `fromBlock` and `toBlock` to be modified by the user when calling  `fetchToken` or `applyStateChanges`